### PR TITLE
Remove variables that are set and never used

### DIFF
--- a/src/libhelix-mp3/dqchan.c
+++ b/src/libhelix-mp3/dqchan.c
@@ -245,7 +245,7 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound, FrameHeader 
 					ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi)
 {
 	int i, j, w, cb;
-	int cbStartL, cbEndL, cbStartS, cbEndS;
+	int cbEndL, cbStartS, cbEndS;
 	int nSamps, nonZero, sfactMultiplier, gbMask;
 	int globalGain, gainI;
 	int cbMax[3];
@@ -253,7 +253,6 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound, FrameHeader 
 	
 	/* set default start/end points for short/long blocks - will update with non-zero cb info */
 	if (sis->blockType == 2) {
-		cbStartL = 0;
 		if (sis->mixedBlock) { 
 			cbEndL = (fh->ver == MPEG1 ? 8 : 6); 
 			cbStartS = 3; 
@@ -264,7 +263,6 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound, FrameHeader 
 		cbEndS = 13;
 	} else {
 		/* long block */
-		cbStartL = 0;
 		cbEndL =   22;
 		cbStartS = 13;
 		cbEndS =   13;

--- a/src/libhelix-mp3/huffman.c
+++ b/src/libhelix-mp3/huffman.c
@@ -386,7 +386,6 @@ int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, in
 	FrameHeader *fh;
 	SideInfo *si;
 	SideInfoSub *sis;
-	ScaleFactorInfo *sfi;
 	HuffmanInfo *hi;
 
 	/* validate pointers */
@@ -396,7 +395,6 @@ int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, in
 	fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
 	si = ((SideInfo *)(mp3DecInfo->SideInfoPS));
 	sis = &si->sis[gr][ch];
-	sfi = ((ScaleFactorInfo *)(mp3DecInfo->ScaleFactorInfoPS));
 	hi = (HuffmanInfo*)(mp3DecInfo->HuffmanInfoPS);
 
 	if (huffBlockBits < 0)

--- a/src/libhelix-mp3/scalfact.c
+++ b/src/libhelix-mp3/scalfact.c
@@ -208,7 +208,7 @@ static const char NRTab[6][3][4] = {
 static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoSub *sfis, int gr, int ch, int modeExt, ScaleFactorJS *sfjs)
 {
 
-	int i, sfb, sfcIdx, btIdx, nrIdx, iipTest;
+	int i, sfb, sfcIdx, btIdx, nrIdx;
 	int slen[4], nr[4];
 	int sfCompress, preFlag, intensityScale;
 	
@@ -298,7 +298,6 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoS
 	if(sis->blockType == 2) {
 		if(sis->mixedBlock) {
 			/* do long block portion */
-			iipTest = (1 << slen[0]) - 1;
 			for (sfb=0; sfb < 6; sfb++) {
 				sfis->l[sfb] = (char)GetBits(bsi, slen[0]);
 			}
@@ -312,7 +311,6 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoS
 
 		/* remaining short blocks, sfb just keeps incrementing */
 		for (    ; nrIdx <= 3; nrIdx++) {
-			iipTest = (1 << slen[nrIdx]) - 1;
 			for (i=0; i < nr[nrIdx]; i++, sfb++) {
 				sfis->s[sfb][0] = (char)GetBits(bsi, slen[nrIdx]);
 				sfis->s[sfb][1] = (char)GetBits(bsi, slen[nrIdx]);
@@ -325,7 +323,6 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoS
 		/* long blocks */
 		sfb = 0;
 		for (nrIdx = 0; nrIdx <= 3; nrIdx++) {
-			iipTest = (1 << slen[nrIdx]) - 1;
 			for(i=0; i < nr[nrIdx]; i++, sfb++) {
 				sfis->l[sfb] = (char)GetBits(bsi, slen[nrIdx]);
 			}

--- a/src/libhelix-mp3/subband.c
+++ b/src/libhelix-mp3/subband.c
@@ -60,7 +60,6 @@
 int Subband(MP3DecInfo *mp3DecInfo, short *pcmBuf)
 {
 	int b;
-	HuffmanInfo *hi;
 	IMDCTInfo *mi;
 	SubbandInfo *sbi;
 
@@ -68,7 +67,6 @@ int Subband(MP3DecInfo *mp3DecInfo, short *pcmBuf)
 	if (!mp3DecInfo || !mp3DecInfo->HuffmanInfoPS || !mp3DecInfo->IMDCTInfoPS || !mp3DecInfo->SubbandInfoPS)
 		return -1;
 
-	hi = (HuffmanInfo *)mp3DecInfo->HuffmanInfoPS;
 	mi = (IMDCTInfo *)(mp3DecInfo->IMDCTInfoPS);
 	sbi = (SubbandInfo*)(mp3DecInfo->SubbandInfoPS);
 


### PR DESCRIPTION
These produce warnings while compiling, which pollutes compilation output