### PR TITLE
Remove flush() in destructor

### DIFF
--- a/src/AACDecoderHelix.h
+++ b/src/AACDecoderHelix.h
@@ -31,7 +31,7 @@ class AACDecoderHelix : public CommonHelix {
         }
 
         virtual ~AACDecoderHelix(){
-            end();
+            end(false);
         }
 
         void setInfoCallback(AACInfoCallback cb, void* caller=nullptr){
@@ -44,10 +44,13 @@ class AACDecoderHelix : public CommonHelix {
         }
 
         /// Releases the reserved memory
-        virtual void end() override {
+        virtual void end(bool shuld_flush = true) override {
             LOG_HELIX(Debug, "end");
             if (decoder!=nullptr){
-                flush();
+                if (shuld_flush)
+                {
+                    flush();
+                }
                 AACFreeDecoder(decoder);
                 decoder = nullptr;
             }

--- a/src/CommonHelix.h
+++ b/src/CommonHelix.h
@@ -50,7 +50,7 @@ class CommonHelix   {
 
         virtual ~CommonHelix(){
             if (active){
-                end();
+                end(false);
             }
             if (pcm_buffer!=nullptr){
                 delete[] pcm_buffer;
@@ -116,7 +116,7 @@ class CommonHelix   {
         }
 
         /// Releases the reserved memory
-        virtual void end(){
+        virtual void end(bool shuld_flush = true){
             active = false;
         }
 

--- a/src/MP3DecoderHelix.h
+++ b/src/MP3DecoderHelix.h
@@ -45,7 +45,7 @@ class MP3DecoderHelix : public CommonHelix {
         }
 
         virtual ~MP3DecoderHelix(){
-            end();
+            end(false);
         }
 
         void setInfoCallback(MP3InfoCallback cb, void* caller=nullptr){
@@ -63,9 +63,12 @@ class MP3DecoderHelix : public CommonHelix {
         }
 
         /// Releases the reserved memory
-        virtual void end() override {
+        virtual void end(bool shuld_flush = true) override {
             LOG_HELIX(Debug, "end");
-            flush();
+            if(shuld_flush)
+            {
+                flush();
+            }
 
             if (decoder!=nullptr){
                 MP3FreeDecoder(decoder);


### PR DESCRIPTION
if data is not feed, at  destructor call. flush() routine block the code.
