### PR TITLE
Use little-endian order by default for U64 struct

### DIFF
--- a/src/libhelix-aac/assembly.h
+++ b/src/libhelix-aac/assembly.h
@@ -558,14 +558,14 @@ static __inline int CLZ(int x)
 typedef union _U64 {
 	Word64 w64;
 	struct {
-#ifdef __XTENSA__		
-		unsigned int lo32;
-		signed int   hi32;
-#else
+#if defined(__POWERPC__) || defined(__powerpc__)
 		/* PowerPC = big endian */
 		signed int   hi32;
 		unsigned int lo32;
-#endif		
+#else
+		unsigned int lo32;
+		signed int   hi32;
+#endif
 	} r;
 } U64;
 


### PR DESCRIPTION
ESP32s with RISC-V cores lacks  `__XTENSA__` macro and wrongly falls into big-endian order.

Initially proposed change to fix it was:
```
#if defined (__XTENSA__) || defined(__riscv)
     // use little endian order
#else
     // use BIG endian order
#endif
```

which was changed to:
```
#if defined(__POWERPC__) or defined(__powerpc__)
     // use BIG endian order
#else 
     // use little endian order
#endif 
```
The rationale is that most 32-bit Arduino platforms default to little-endian, whereas PowerPC is strictly big-endian.