### PR TITLE
Enable AAC decoder build on Apple/MacOS

### DIFF
--- a/src/libhelix-aac/aacdec.h
+++ b/src/libhelix-aac/aacdec.h
@@ -64,6 +64,8 @@
 #
 #elif defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__))
 #
+#elif defined(__GNUC__) && defined(__APPLE__)
+#
 #elif defined(_OPENWAVE_SIMULATOR) || defined(_OPENWAVE_ARMULATOR)
 #
 #elif defined(_SOLARIS) && !defined(__GNUC__)

--- a/src/libhelix-aac/assembly.h
+++ b/src/libhelix-aac/assembly.h
@@ -429,7 +429,7 @@ static inline Word64 MADD64(Word64 sum64, int x, int y)
 /* toolchain:           x86 gcc
  * target architecture: x86
  */
-#elif defined(__GNUC__) && (defined(__i386__) || defined(__amd64__)) || (defined (_SOLARIS) && !defined (__GNUC__) && defined(_SOLARISX86))
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__amd64__) || defined(__APPLE__)) || (defined (_SOLARIS) && !defined (__GNUC__) && defined(_SOLARISX86))
 
 typedef long long Word64;
 


### PR DESCRIPTION
While trying to build the library on my MacBook (Apple M1 Pro, macOS 15.6.1), I've encountered errors in AAC-part of the code. The MP3 codec has the `__APPLE__` define that allows compilation on macOS, but AAC code is missing it. Not sure why exactly, there might be a reason for it, but it seems like an easy fix.

I wrote a small sketch to test the codec:

```
#include "AudioTools.h"
#include "AudioTools/Disk/AudioSourceSTD.h"
#include "AudioTools/AudioCodecs/CodecAACHelix.h"
#include "AudioTools/AudioLibs/PortAudioStream.h"

PortAudioStream out;
AudioSourceSTD source("/Users/<User>/sound/", ".aac");
AACDecoderHelix decoder;

AudioPlayer player(source, out, decoder);

int main()
{
  AudioToolsLogger.begin(Serial, AudioToolsLogLevel::Info);

  auto cfg = out.defaultConfig();
  out.begin(cfg);

  player.begin();
  source.begin();

  while (true) {
    player.copy();
  }
  return 0;
}
```

Used AAC audio samples from [here](https://docs.espressif.com/projects/esp-adf/en/latest/design-guide/audio-samples.html).

The audio player is able to play the files, logs look good as well. 